### PR TITLE
bugfix: server never able to start because `app.use` when adding bodyparser middleware is misspelled

### DIFF
--- a/template/index.js
+++ b/template/index.js
@@ -5,7 +5,7 @@ import cors from 'kcors';
 
 const app = new Koa();
 
-app.user(bodyParser());
+app.use(bodyParser());
 
 app.use((ctx, next) => {
   const start = new Date();


### PR DESCRIPTION
bug(typo): method call `app.user` for adding bodyparser middleware misspelled, change to `app.use`